### PR TITLE
Updated eslintrc with new name for deprecated rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -362,7 +362,7 @@
     // require a space after certain keywords (off by default)
     "space-before-blocks": 0,
     // require or disallow space before blocks (off by default)
-    "space-before-function-parentheses": {
+    "space-before-function-paren": {
       "anonymous": "always",
       "named": "always"
     },


### PR DESCRIPTION
deprecated rule "space-before-function-parentheses" updated to "space-before-function-paren"

Details:
https://github.com/eslint/eslint/blob/master/docs/rules/space-before-function-parentheses.md
